### PR TITLE
Fix: Add Close (X) Button to Mobile Navbar for Better Navigation

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -108,8 +108,8 @@ const Navbar = () => {
             onClick={() => setIsMenuOpen(!isMenuOpen)}
             className="lg:hidden"
           >
-            <img src={isMenuOpen ? close : hamburger} className="h-8" />
-          </button>
+            <img  src={isMenuOpen ? close : hamburger} className={`h-8 ${isMenuOpen ? " fixed top-[1rem] " : " "}    z-[100] `} />
+            </button>
         )}
       </header>
 


### PR DESCRIPTION
This pull request resolves the issue where the mobile navbar lacked a close (X) button, causing the menu to remain open and obstruct the view of the page content. The following changes have been made:

Added a close (X) button to the mobile navbar.
Implemented functionality to toggle the menu visibility when the close button is clicked.
Improved user experience by ensuring the menu can be easily closed after opening, allowing smooth navigation on mobile devices.

Changes:
 -optimised tailwind CSS 
-Added close button to the mobile navbar.

Impact:
This fix improves the overall user experience on mobile by allowing users to easily close the navbar and access the page content after the menu has been opened.

![Screenshot 2024-10-11 231817](https://github.com/user-attachments/assets/fa6569e2-a52d-4b1a-afb3-a19c78f2b56e)
